### PR TITLE
Intentを引数に渡す

### DIFF
--- a/discordbot.py
+++ b/discordbot.py
@@ -19,8 +19,11 @@ from niconico import NicoNico
 
 # DiscordBot
 DISCORD_BOT_TOKEN = getenv("DISCORD_BOT_TOKEN")
+intents = discord.Intents.default()
+intents.members = True
+intents.message_content = True
 # Botの接頭辞を ! にする
-bot = commands.Bot(command_prefix="!")
+bot = commands.Bot(command_prefix="!", intents=intents)
 
 # Annict
 ANNICT_API_KEY = getenv("ANNICT_API_KEY")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-py-cord[voice]>=1.7.3
-ffmpeg>=1.4
+py-cord[voice]==2.0
+ffmpeg==1.4
 yt-dlp==2022.6.29
 google-api-python-client==2.52.0
 tweepy==4.10.0


### PR DESCRIPTION
最近のpycordは明示的にIntentを渡してやらないとうまく動かないらしいです
`on_message` でprintデバッグしてたらそもそも `ctx.content` にメッセージが入ってなくて、全部空文字列になってました

Intentについて詳しくはググってほしいですが、簡単に言うと「このBotがDiscordからどの情報を受け取りたいか？」を選択するための機能です
- "Intent" が「意図」という意味の単語なので雰囲気で察してほしい

pycord公式リポジトリのexampleを見るとデフォルトのIntentの他、message_contentも有効にすると良い感じっぽい
https://github.com/Pycord-Development/pycord/blob/283db543c267d0ec51526b17a5728bed4d6516fe/examples/basic_bot.py#L14-L18

実際これを付与するようにしたら `ctx.content` にちゃんとメッセージが入るようになった

で、これは多分Discrod developers portalでギラティナの設定をいじる必要があります　以下の通りmessage contentをtrueにしてやってください
![image](https://user-images.githubusercontent.com/12756563/179820156-0cbcbbab-a9d4-4629-9337-9806eb79e3f2.png)


closes #90 たぶん message_content を有効にする必要がある/ない時期がダブっていたのだと思う